### PR TITLE
增加一个 Editor 方法 ReGenerateProjectAssemblyReference

### DIFF
--- a/Editor/InitEditor/CodeModeChangeHelper.cs
+++ b/Editor/InitEditor/CodeModeChangeHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using UnityEditor;
+using UnityEngine;
 
 namespace ET
 {
@@ -119,7 +121,7 @@ namespace ET
         }
 
         [MenuItem("ET/Loader/ReGenerateProjectAssemblyReference")]
-        private static void ReGenerateProjectAssemblyReference()
+        public static void ReGenerateProjectAssemblyReference()
         {
             var GlobalConfig = Resources.Load<GlobalConfig>("GlobalConfig");
             ChangeToCodeMode(GlobalConfig.CodeMode.ToString());

--- a/Editor/InitEditor/CodeModeChangeHelper.cs
+++ b/Editor/InitEditor/CodeModeChangeHelper.cs
@@ -117,5 +117,13 @@ namespace ET
         {
             File.WriteAllText(path, $"{{ \"reference\": \"ET.{modelDir}\" }}");
         }
+
+        [MenuItem("ET/Loader/ReGenerateProjectAssemblyReference")]
+        private static void ReGenerateProjectAssemblyReference()
+        {
+            var GlobalConfig = Resources.Load<GlobalConfig>("GlobalConfig");
+            ChangeToCodeMode(GlobalConfig.CodeMode.ToString());
+            AssetDatabase.Refresh();
+        }
     }
 }


### PR DESCRIPTION
当前只有在 GlobalConfig 修改 或 INITED 初始化的时候才会生成 AssemblyReference。但还有一些情况下需要快捷的重新生成 AssemblyReference，比如更新一个包的时候，项目本体已经 Inited 标记过，而新包拉下来是缺少 AssemblyReference 的。